### PR TITLE
Accept dot as time separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Pads the specified integer with leading zeroes to ensure it has at least `places
 
 ## Changelog
 
+1.0.1: `launder.time` will now also accept a `.` (dot) as the separator (until now only `:` colon was recognized)
+
 1.0.0: switched to a maintained, secure fork of lodash 3, declared 1.0.0 as this has been a stable part of Apostrophe for years.
 
 0.1.3: `launder.booleanOrNull` broken out from `launder.addBooleanFilterCriteria` so that you can get the tri-state value without modifying a criteria object.

--- a/index.js
+++ b/index.js
@@ -356,7 +356,7 @@ function Launder(options) {
   self.time = function(time, def) {
     time = self.string(time).toLowerCase();
     time = time.trim();
-    var components = time.match(/^(\d+)(:(\d+))?(:(\d+))?\s*(am|pm|AM|PM|a|p|A|M)?$/);
+    var components = time.match(/^(\d+)([:|.](\d+))?([:|.](\d+))?\s*(am|pm|AM|PM|a|p|A|M)?$/);
     if (components) {
       var hours = parseInt(components[1], 10);
       var minutes = (components[3] !== undefined) ? parseInt(components[3], 10) : 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A sanitize module for the people. Built for apostrophecms.",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -421,6 +421,11 @@ describe('float', function(){
 			assert(launder.time('3.52:05pm') === '15:52:05');
 			assert(launder.time('4:32.23a') === '04:32:23');
 		});
+		it('should accept not accept any time separator', function(){
+			assert(launder.time('3q52b05pm') !== '15:52:05');
+			assert(launder.time('4 32 23a') !== '04:32:23');
+			assert(launder.time('12Qpm') !== '12:00:00');
+		});
 		it('should handle no minutes', function(){
 			assert(launder.time('4 PM') === '16:00:00');
 		});

--- a/test/test.js
+++ b/test/test.js
@@ -413,6 +413,14 @@ describe('float', function(){
 			assert(launder.time('4:30pm') === '16:30:00');
 			assert(launder.time('4:30PM') === '16:30:00');
 		});
+		it('should accept dot as time separator', function(){
+			assert(launder.time('4.30pm') === '16:30:00');
+			assert(launder.time('4.30PM') === '16:30:00');
+		});
+		it('should accept dot and colon mixed as time separator', function(){
+			assert(launder.time('3.52:05pm') === '15:52:05');
+			assert(launder.time('4:32.23a') === '04:32:23');
+		});
 		it('should handle no minutes', function(){
 			assert(launder.time('4 PM') === '16:00:00');
 		});


### PR DESCRIPTION
This PR makes `launder.time` able to accept `.` (dot) as the separator between hours, minutes and seconds. Separators can be mixed.

Added tests to cover this, existing tests are passing, I did the version bump and README change so this one should be easy to merge and release.