### PR TITLE
Fix toString() error on select

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,9 +152,12 @@ function Launder(options) {
     var choice;
     if (typeof(choices[0]) === 'object') {
       choice = _.find(choices, function(choice) {
-        return choice.value.toString() === s;
+        if (choice.value != null) {
+          return choice.value.toString() === s;
+        }
+        return null;
       });
-      if (choice !== undefined) {
+      if (choice != null) {
         return choice.value;
       }
       return def;


### PR DESCRIPTION
Fix error 
```
return choice.value.toString() === s;
                               ^
TypeError: Cannot read property 'toString' of null
    at /app/node_modules/launder/index.js:155:28
```

when no value in choice. It happens a lot in our widgets.